### PR TITLE
fix(ajv): fixed `AjvContainer`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
   },
   "keywords": [
     "maeum",
+    "jsonschema",
+    "json-schema",
+    "validation",
     "schema",
     "schema-controller"
   ],

--- a/src/SchemaController.ts
+++ b/src/SchemaController.ts
@@ -121,6 +121,18 @@ export class SchemaController {
     this.#stringify = stringify;
   }
 
+  get schema(): Readonly<SchemaContainer> {
+    return this.#schema;
+  }
+
+  get ajv(): Readonly<AjvContainer> {
+    return this.#ajv;
+  }
+
+  get stringify(): Readonly<StringifyContainer> {
+    return this.#stringify;
+  }
+
   getValidator<T>(id: string) {
     const schema = this.#schema.getItemOrThrow(id);
     const validator = this.#ajv.getCompileValidator<T>({

--- a/src/modules/AjvContainer.ts
+++ b/src/modules/AjvContainer.ts
@@ -1,4 +1,5 @@
 import type { ISchemaControllerBootstrapOption } from '#/interfaces/ISchemaControllerBootstrapOption';
+import type { ISchemaDatabaseItem } from '#/interfaces/ISchemaDatabaseItem';
 import { getCacheKey } from '#/modules/getCacheKey';
 import type { RouteDefinition } from '@fastify/ajv-compiler';
 import type { Options as AjvOptions, AnySchema, AnySchemaObject } from 'ajv';
@@ -81,7 +82,7 @@ export class AjvContainer {
     }
 
     const metadata = rawMetadata as RouteDefinition;
-    const schema = metadata.schema as AnySchemaObject;
+    const schema = metadata.schema as ISchemaDatabaseItem;
 
     const cacheKey = getCacheKey(metadata);
     const cache = this.#cache[cacheKey];
@@ -90,7 +91,7 @@ export class AjvContainer {
       return cache as ValidateFunction<T>;
     }
 
-    const validator = this.#ajv.compile<T>({ ...schema, $async: false });
+    const validator = this.#ajv.compile<T>({ ...schema.schema, $async: false });
     this.#cache[cacheKey] = validator;
 
     return validator;


### PR DESCRIPTION
- fixed `AjvContainer` problem
  -   fixed `getCompileValidator` function fails to compile schema if there is no cache